### PR TITLE
fix: resolve multibyte and dead-key input not working properly

### DIFF
--- a/lua/clackity/core/handler.lua
+++ b/lua/clackity/core/handler.lua
@@ -25,15 +25,18 @@ function M.process_keystroke(key)
 
   if not target_line then return true end
 
-  local target_char = target_line:sub(col_idx + 1, col_idx + 1)
+  local target_char = vim.fn.strcharpart(target_line, col_idx, 1)
 
   local is_match = (key == target_char)
   local status = is_match and "correct" or "error"
 
+  local byte_start = vim.fn.byteidx(target_line, col_idx)
+  local byte_end = vim.fn.byteidx(target_line, col_idx + 1)
+
   if is_match then
-    ui.mark_correct(state.bufnr, line_idx, col_idx)
+    ui.mark_correct(state.bufnr, line_idx, byte_start, byte_end)
   else
-    ui.mark_error(state.bufnr, line_idx, col_idx)
+    ui.mark_error(state.bufnr, line_idx, byte_start, byte_end)
   end
 
   local latency = current_time - state.last_key_time
@@ -50,7 +53,7 @@ function M.process_keystroke(key)
   table.insert(state.stats_log, log)
   state.last_key_time = current_time
 
-  if state.current_col >= #target_line then
+  if state.current_col >= vim.fn.strchars(target_line) then
     state.current_col = 0
     state.current_row = state.current_row + 1
 
@@ -60,7 +63,7 @@ function M.process_keystroke(key)
     end
   end
 
-  ui.move_cursor(state.win_id, state.current_row, state.current_col)
+  ui.move_cursor(state.win_id, state.current_row, byte_end)
   return false
 end
 

--- a/lua/clackity/core/handler.lua
+++ b/lua/clackity/core/handler.lua
@@ -63,7 +63,10 @@ function M.process_keystroke(key)
     end
   end
 
-  ui.move_cursor(state.win_id, state.current_row, byte_end)
+  local active_line = state.target_lines[state.current_row + 1]
+  local cursor_byte = vim.fn.byteidx(active_line, state.current_col)
+
+  ui.move_cursor(state.win_id, state.current_row, cursor_byte)
   return false
 end
 

--- a/lua/clackity/core/init.lua
+++ b/lua/clackity/core/init.lua
@@ -43,7 +43,25 @@ function M.start_lesson()
   state.target_lines = lines
   ui.render_lines(state.bufnr, lines)
   ui.move_cursor(state.win_id, 0, 0)
-  input.attach_lesson(state.bufnr)
+  local actions = {
+    on_quit = M.quit,
+    on_menu = M.show_menu,
+    on_restart = M.start_lesson,
+    on_keystroke = function(char)
+      local is_finished = handler.process_keystroke(char)
+
+      if is_finished then
+        vim.schedule(function()
+          M.post_lesson()
+        end)
+      end
+
+      return is_finished
+    end
+  }
+
+  -- Inject!
+  input.attach_lesson(state.bufnr, actions)
 end
 
 --- Input handler callback

--- a/lua/clackity/input/init.lua
+++ b/lua/clackity/input/init.lua
@@ -66,7 +66,7 @@ function M.typing_loop(bufnr, actions)
     end
 
     -- Esc (\27)
-    if char == "\27" then
+    if char == "\27" or char == "\17" then
       actions.on_menu()
       break
     end

--- a/lua/clackity/input/init.lua
+++ b/lua/clackity/input/init.lua
@@ -32,21 +32,60 @@ local function smart_clear(bufnr, keys_to_check)
   end
 end
 
-function M.attach_lesson(bufnr)
+function M.attach_lesson(bufnr, actions)
   -- TODO: add all the other keys
   -- TODO: add unused keys (like tab)
   smart_clear(bufnr, { "<CR>", "s", "q", "m", "r" })
-  for i = 1, #keys do
-    local char = keys:sub(i, i)
-    vim.keymap.set("n", char, function()
-      require("clackity.core").handle_input(char)
-    end, { buffer = bufnr, nowait = true, noremap = true, silent = true })
-  end
 
-  -- Lesson control
-  vim.keymap.set("n", "<C-q>", require("clackity.core").quit, { buffer = bufnr, silent = true })
-  vim.keymap.set("n", "<C-r>", require("clackity.core").start_lesson, { buffer = bufnr, silent = true })
-  vim.keymap.set("n", "<Esc>", require("clackity.core").show_menu, { buffer = bufnr, silent = true })
+  vim.schedule(function()
+    M.typing_loop(bufnr, actions)
+  end)
+  -- for i = 1, #keys do
+  --   local char = keys:sub(i, i)
+  --   vim.keymap.set("n", char, function()
+  --     require("clackity.core").handle_input(char)
+  --   end, { buffer = bufnr, nowait = true, noremap = true, silent = true })
+  -- end
+  --
+  -- -- Lesson control
+  -- vim.keymap.set("n", "<C-q>", require("clackity.core").quit, { buffer = bufnr, silent = true })
+  -- vim.keymap.set("n", "<C-r>", require("clackity.core").start_lesson, { buffer = bufnr, silent = true })
+  -- vim.keymap.set("n", "<Esc>", require("clackity.core").show_menu, { buffer = bufnr, silent = true })
+end
+
+function M.typing_loop(bufnr, actions)
+  vim.cmd("redraw")
+
+  while true do
+    local ok, char = pcall(vim.fn.getcharstr)
+
+    -- Ctrl+C or process killed
+    if not ok or char == "\3" then
+      actions.on_quit()
+      break
+    end
+
+    -- Esc (\27)
+    if char == "\27" then
+      actions.on_menu()
+      break
+    end
+
+    -- Ctrl+R (\18)
+    if char == "\18" then
+      actions.on_restart()
+      break
+    end
+
+    -- Pass the raw character to whatever callback was injected
+    local is_finished = actions.on_keystroke(char)
+
+    vim.cmd("redraw")
+
+    if is_finished then
+      break
+    end
+  end
 end
 
 function M.attach_main(bufnr)

--- a/lua/clackity/ui/init.lua
+++ b/lua/clackity/ui/init.lua
@@ -133,7 +133,8 @@ function M.mark_error(buf, row, col_start, col_end)
 end
 
 function M.move_cursor(win, row, col)
-  pcall(vim.api.nvim_win_set_cursor, win, { row + 1, col })
+  vim.api.nvim_win_set_cursor(win, { row + 1, col })
+  vim.api.nvim__redraw({ valid = false, flush = true, cursor = true })
 end
 
 function M.close(win_id)

--- a/lua/clackity/ui/init.lua
+++ b/lua/clackity/ui/init.lua
@@ -124,12 +124,12 @@ function M.render_lines(buf, words)
   end
 end
 
-function M.mark_correct(buf, row, col)
-  highlight.paint(buf, "ClackityCorrect", row, col, col + 1)
+function M.mark_correct(buf, row, col_start, col_end)
+  highlight.paint(buf, "ClackityCorrect", row, col_start, col_end)
 end
 
-function M.mark_error(buf, row, col)
-  highlight.paint(buf, "ClackityError", row, col, col + 1)
+function M.mark_error(buf, row, col_start, col_end)
+  highlight.paint(buf, "ClackityError", row, col_start, col_end)
 end
 
 function M.move_cursor(win, row, col)


### PR DESCRIPTION
This completely replaces the keymap event listener with a raw getcharstr() loop, and uses the nvim__redraw C-API to force terminal flushes. This allows native OS composition of dead-keys (like ñ and á).

Fixes #2 